### PR TITLE
Fix empty prefix error

### DIFF
--- a/src/Behat/SpawnerExtension/Listener/SuiteListener.php
+++ b/src/Behat/SpawnerExtension/Listener/SuiteListener.php
@@ -164,7 +164,10 @@ class SuiteListener implements EventSubscriberInterface
     {
         $builder = new ProcessBuilder();
         $builder->setWorkingDirectory($workingDirectory);
-        $builder->setPrefix($execPrefix);
+
+        if ($execPrefix) {
+            $builder->setPrefix($execPrefix);
+        }
 
         foreach ($arguments as $arg) {
             $builder->add($arg);


### PR DESCRIPTION
Empty prefix on windows causes "'' is not recognized as an internal or external command, operable program or batch file."
